### PR TITLE
[SECENG-2457] Enable permissions filtering

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -55,3 +55,16 @@ variable "permissions_boundary" {
   description = "Permissions Boundary ARN to attach to our created user"
   default     = null
 }
+
+
+variable "enable_ip_filter" {
+  type        = bool
+  description = "If permissions policy is filtered by IP"
+  default     = false
+}
+
+variable "ip_filtered_list" {
+  type        = list(any)
+  description = "List of IPs to filter by in permissions policy"
+  default     = []
+}


### PR DESCRIPTION
This PR modifies the users permissions policy assignments to allow inclusion of ip filtering.
This module is being used to create various AWS IAM regular users, which are gonna be hardened as part of the notion initiative [Objective 1: Implement IP restrictions on AWS service accounts (Core)](https://www.notion.so/eburydata/Objective-1-Implement-IP-restrictions-on-AWS-service-accounts-Core-1a876990281580709902f51db4dc0512) using ip filtering.
Right now the module does not allow it, being the rationale of the changes